### PR TITLE
Argument variable keyaliasName should be quoted

### DIFF
--- a/GooglePlayPlugins/com.google.android.appbundle/Editor/Scripts/Internal/BuildTools/ApkSigner.cs
+++ b/GooglePlayPlugins/com.google.android.appbundle/Editor/Scripts/Internal/BuildTools/ApkSigner.cs
@@ -174,7 +174,7 @@ namespace Google.Android.AppBundle.Editor.Internal.BuildTools
                 "-jar {0} sign --ks {1} --ks-key-alias {2} --pass-encoding utf-8 {3}{4}",
                 CommandLine.QuotePath(GetApkSignerJarPath()),
                 CommandLine.QuotePath(keystoreName),
-                keyaliasName,
+                CommandLine.QuotePath(keyaliasName),
                 additionalArguments,
                 CommandLine.QuotePath(filePath));
 


### PR DESCRIPTION
It is possible to have a KeyAlias with white spaces within, in that case the signing process will fail, adding quotes to start and finish of the string fixes the issue. Here I solved the issue using the same method that was used in the other arguments CommandLine.QuotePath.

Tested on Unity 2019.3.7f1 with a KayAlias in the format: "firstName secondName thirdName"