### PR TITLE
Handled empty purchases list.

### DIFF
--- a/GooglePlayPlugins/com.google.play.billing/Runtime/Scripts/GooglePlayStoreImpl.cs
+++ b/GooglePlayPlugins/com.google.play.billing/Runtime/Scripts/GooglePlayStoreImpl.cs
@@ -566,7 +566,13 @@ namespace Google.Play.Billing
             var debugMessage = JniUtils.GetDebugMessageFromBillingResult(billingResult);
             if (responseCode == BillingResponseCode.Ok)
             {
-                var purchasesList = _jniUtils.ParseJavaPurchaseList(javaPurchasesList);
+                var purchasesList = _jniUtils.ParseJavaPurchaseList(javaPurchasesList).ToList();
+                if (purchasesList.Count == 0)
+                {
+                    _productInPurchaseFlow = null;
+                    return;
+                }
+
                 _inventory.UpdatePurchaseInventory(purchasesList);
                 // Unity IAP only supports one purchase at a time.
                 Purchase purchase = purchasesList.First();

--- a/GooglePlayPlugins/com.google.play.billing/Runtime/Scripts/Internal/JniUtils.cs
+++ b/GooglePlayPlugins/com.google.play.billing/Runtime/Scripts/Internal/JniUtils.cs
@@ -174,6 +174,11 @@ namespace Google.Play.Billing.Internal
         public IEnumerable<Purchase> ParseJavaPurchaseList(AndroidJavaObject javaPurchasesList)
         {
             var parsedPurchasesList = new List<Purchase>();
+            if (javaPurchasesList == null)
+            {
+                return parsedPurchasesList;
+            }
+
             var size = javaPurchasesList.Call<int>("size");
             for (var i = 0; i < size; i++)
             {


### PR DESCRIPTION
## Issue Description

Fixing payment issue while the app is running in background throws `NullReferenceException`.

## Underlying Reason

Fixing the payment issue triggers a new purchase update from native side with null purchases list when the application is running in background, but the C# side doesn't handle this situation well and throws a `NullReferenceException`. Actual underlying reason might be triggering the purchase update with null purchases list for this specific case, but considering the annotations in the native code and XML documentations in the C# code, having a null purchases list looks like a valid case and should be handled nonetheless.

## Fix

Fix contains three main modifications:

### Fix calling a method (`size()`) on a nullable list coming from native side

In `GooglePlayBilling.aar`, `PurchasesUpdatedListener.onPurchasesUpdated()` callback declares a nullable purchases list as follows when it's decompiled:

```
public interface PurchasesUpdatedListener {
    void onPurchasesUpdated(@NonNull BillingResult var1, @Nullable List<Purchase> var2);
}
```

but in `JniUtils.ParseJavaPurchaseList()`, there's no null check before calling the native `size()` method on it, hence it throws `NullReferenceException`.

### Fix handling empty purchases list

`JniUtils.ParseJavaPurchaseList()` has following XML doc for the return value:

```
/// <returns>An IEnumerable of <cref="Purchase"/>. The IEnumerable could be empty.</returns>
```

but `GooglePlayStoreImpl.ParsePurchaseResult()` calls `First()` on the list, hence it throws `InvalidOperationException` when the list is empty.

### Fix enumerating `IEnumerable` multiple times

`GooglePlayStoreImpl.ParsePurchaseResult()` enumerates `IEnumerable` purchases list multiple times (first with `_inventory.UpdatePurchaseInventory()` call and then with `purchasesList.First()` call). Added `ToList()` to evaluate it once and enumerate it multiple times safely.

---

Related issue: https://issuetracker.google.com/issues/171860953