### PR TITLE
Add git url descriptions to install Unity Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ There are 4 different options for obtaining the plugins:
 
 *   `git clone` this repository into the **Assets** folder of your Unity project
 
-
-
 ## Installing the plugins
 
 For all cases except `git clone` follow the instructions to

--- a/README.md
+++ b/README.md
@@ -22,16 +22,20 @@ libaries.](//android-developers.googleblog.com/2019/01/get-your-apps-ready-for-6
 
 ## Downloading the plugins
 
-There are 3 different options for obtaining the plugins:
+There are 4 different options for obtaining the plugins:
 
 *   Download individual plugins as `.unitypackage` files or Unity Package
     Manager (`.tgz`) files from
     [Google APIs for Unity](//developers.google.com/unity)
 
+*   Add individual plugins by *git url* using the Unity Package Manager. E.g. For **com.google.play.core** use `https://github.com/google/play-unity-plugins.git?path=/GooglePlayPlugins/com.google.play.core` 
+
 *   Download the latest release from this project's
     [releases page](//github.com/google/play-unity-plugins/releases)
 
 *   `git clone` this repository into the **Assets** folder of your Unity project
+
+
 
 ## Installing the plugins
 


### PR DESCRIPTION
Packages can be installed in unity using a path directive [(Unity dokumentation)](https://docs.unity3d.com/Manual/upm-git.html)
This pull request adds a description how to used this option for the google play unity plugins.