### PR TITLE
Updated the dependencies to correct versions in Integrity API

### DIFF
--- a/GooglePlayPlugins/com.google.play.integrity/package.json
+++ b/GooglePlayPlugins/com.google.play.integrity/package.json
@@ -8,7 +8,7 @@
     "name": "Google LLC"
   },
   "dependencies": {
-    "com.google.play.common": "1.8.1",
-    "com.google.play.core": "1.8.1"
+    "com.google.play.common": "1.8.2",
+    "com.google.play.core": "1.8.2"
   }
 }


### PR DESCRIPTION
Things like `PlayCoreConstants.IntegrityPackagePrefix` are available in `com.google.play.core`:`1.8.2` and not `1.8.1`.
When importing this package now, it produces compilation errors.