### PR TITLE
Updating dependencies in app-update to support Android 14

### DIFF
--- a/GooglePlayPlugins/com.google.play.appupdate/Editor/Dependencies.xml
+++ b/GooglePlayPlugins/com.google.play.appupdate/Editor/Dependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.google.android.play:app-update:2.0.0"/>
+        <androidPackage spec="com.google.android.play:app-update:2.1.0"/>
+        <androidPackage spec="androidx.activity:activity:1.6.0" />
     </androidPackages>
 </dependencies>
-


### PR DESCRIPTION
The App Update plugin doesn't work in Android 14, throwing a number errors.

This patch solves the problem by updating App Update to the android package `2.1.0`. Solves the tickets #232 and #236.