### PR TITLE
Fixed symbol zip file not being moved with Unity 2022, include non-batch mode build support.

### DIFF
--- a/GooglePlayPlugins/com.google.android.appbundle/Editor/Scripts/Internal/BuildTools/AppBundleBuilder.cs
+++ b/GooglePlayPlugins/com.google.android.appbundle/Editor/Scripts/Internal/BuildTools/AppBundleBuilder.cs
@@ -90,6 +90,7 @@ namespace Google.Android.AppBundle.Editor.Internal.BuildTools
         private string _packageName;
         private int _versionCode;
         private string _versionName;
+        private ScriptingImplementation _scriptingBackend;
         private PostBuildCallback _createBundleAsyncOnSuccess = delegate { };
         private IEnumerable<IAssetPackManifestTransformer> _assetPackManifestTransformers;
 
@@ -119,6 +120,7 @@ namespace Google.Android.AppBundle.Editor.Internal.BuildTools
             _packageName = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.Android);
             _versionCode = PlayerSettings.Android.bundleVersionCode;
             _versionName = PlayerSettings.bundleVersion;
+            _scriptingBackend = PlayerSettings.GetScriptingBackend(BuildTargetGroup.Android);
 
             _assetPackManifestTransformers = AssetPackManifestTransformerRegistry.Registry.ConstructInstances();
             var initializedManifestTransformers = true;
@@ -762,8 +764,7 @@ namespace Google.Android.AppBundle.Editor.Internal.BuildTools
         {
 #if UNITY_2022_1_OR_NEWER
             // Unity 2022 started adding the scripting backend to the symbol zip's name
-            var scriptingBackend = PlayerSettings.GetScriptingBackend(UnityEditor.Build.NamedBuildTarget.Android);
-            return string.Format("{0}-{1}-v{2}-{3}.symbols.zip", prefix, _versionName, _versionCode, scriptingBackend);
+            return string.Format("{0}-{1}-v{2}-{3}.symbols.zip", prefix, _versionName, _versionCode, _scriptingBackend);
 #else
             return string.Format("{0}-{1}-v{2}.symbols.zip", prefix, _versionName, _versionCode);
 #endif

--- a/GooglePlayPlugins/com.google.android.appbundle/Editor/Scripts/Internal/BuildTools/AppBundleBuilder.cs
+++ b/GooglePlayPlugins/com.google.android.appbundle/Editor/Scripts/Internal/BuildTools/AppBundleBuilder.cs
@@ -760,7 +760,13 @@ namespace Google.Android.AppBundle.Editor.Internal.BuildTools
 
         private string GetSymbolsFileName(string prefix)
         {
+#if UNITY_2022_1_OR_NEWER
+            // Unity 2022 started adding the scripting backend to the symbol zip's name
+            var scriptingBackend = PlayerSettings.GetScriptingBackend(UnityEditor.Build.NamedBuildTarget.Android);
+            return string.Format("{0}-{1}-v{2}-{3}.symbols.zip", prefix, _versionName, _versionCode, scriptingBackend);
+#else
             return string.Format("{0}-{1}-v{2}.symbols.zip", prefix, _versionName, _versionCode);
+#endif
         }
 
         private static void CopyFilesRecursively(DirectoryInfo sourceDirectory, DirectoryInfo destinationDirectory)


### PR DESCRIPTION
Applied change #226 to address an issue in Unity 2022.1 and later where symbol files were no longer being moved correctly because they now include the name of the scripting backend in the symbol file name.

At that time, Fixed a bug that caused an exception to be thrown when executing a build in non-batch mode because PlayerSettings.GetScriptingBackend was accessed from outside the main thread.